### PR TITLE
Fix ASWebAuthenticationSession

### DIFF
--- a/Sources/StravaCombine/StravaConfig.swift
+++ b/Sources/StravaCombine/StravaConfig.swift
@@ -17,6 +17,9 @@ public struct StravaConfig {
     public let client_id: String
     public let client_secret: String
     
+    // scheme name only
+    public let redirect_schema_name: String
+    
     public var fullAuthString: String {
         return scheme + "://" + host + authPath
     }
@@ -42,9 +45,10 @@ public struct StravaConfig {
         return URL(string: fullApiPath(endpoint))!
     }
 
-    public init(client_id: String, client_secret: String, redirect_uri: String) {
+    public init(client_id: String, client_secret: String, redirect_uri: String, redirect_schema_name: String) {
         self.client_id = client_id
         self.client_secret = client_secret
         self.redirect_uri = redirect_uri
+        self.redirect_schema_name = redirect_schema_name
     }
 }

--- a/Sources/StravaCombine/StravaOAuth.swift
+++ b/Sources/StravaCombine/StravaOAuth.swift
@@ -67,7 +67,7 @@ public class StravaOAuth : NSObject, StravaOAuthProtocol {
     }
     private var config: StravaConfig
     // Factory to support mocking ASWebAuthenticationSession
-    public typealias AuthenticationFactory = (URL, String?, @escaping ASWebAuthenticationSession.CompletionHandler) -> (ASWebAuthenticationSession)
+    public typealias AuthenticationFactory = (URL, String?, String?, @escaping ASWebAuthenticationSession.CompletionHandler) -> (ASWebAuthenticationSession)
     private var authenticationFactory: AuthenticationFactory
     // Factory to support authorization via the Strava app. Opening the strava app must be done in this function using the provided URL.
     // When control is returned to the app, it must call processCode with the provided code.
@@ -93,8 +93,8 @@ public class StravaOAuth : NSObject, StravaOAuthProtocol {
             self.authenticationFactory = authenticationSessionFactory
         }
         else {
-            self.authenticationFactory = { url, callbackURLScheme, completionHandler in
-                return ASWebAuthenticationSession(url: url, callbackURLScheme: callbackURLScheme, completionHandler: completionHandler)
+            self.authenticationFactory = { url, callbackURLScheme, appNameScheme, completionHandler in
+                return ASWebAuthenticationSession(url: url, callbackURLScheme: appNameScheme, completionHandler: completionHandler)
             }
         }
         if let openAppFactory = openAppFactory {
@@ -140,7 +140,7 @@ public class StravaOAuth : NSObject, StravaOAuthProtocol {
                 URLQueryItem(name: "response_type", value: "code"),
             ]
 
-            let session = authenticationFactory(components.url!, config.redirect_uri) { callbackURL, error in
+            let session = authenticationFactory(components.url!, config.redirect_uri, config.redirect_schema_name) { callbackURL, error in
                 guard error == nil else {
                     self.tokenSubject.send(nil)
                     self.authorizeSubject?.send(completion: .failure(.authorizationFailed("StravaOAuth.authorize", error.debugDescription)))

--- a/Tests/StravaCombineTests/StravaOAuthTests.swift
+++ b/Tests/StravaCombineTests/StravaOAuthTests.swift
@@ -6,7 +6,7 @@ import AuthenticationServices
 
 final class StravaOAuthTests: XCTestCase {
     private var cancellables = Set<AnyCancellable>()
-    let stravaConfig = StravaConfig(client_id: "client", client_secret: "secret", redirect_uri: "travaartje://www.travaartje.net")
+    let stravaConfig = StravaConfig(client_id: "client", client_secret: "secret", redirect_uri: "travaartje://www.travaartje.net", redirect_schema_name: "travaartje")
 
     override class func setUp() {
     }
@@ -14,8 +14,8 @@ final class StravaOAuthTests: XCTestCase {
     /// Test that a token is retrieved via web-authentication
     func testWebGetToken() {
         let code = "01020304050607"
-        let authenticationSessionFactory: StravaOAuth.AuthenticationFactory = { url, callbackURLScheme, completionHandler in
-            let mock = ASWebAuthenticationSessionMock(url: url, callbackURLScheme: callbackURLScheme, completionHandler: completionHandler)
+        let authenticationSessionFactory: StravaOAuth.AuthenticationFactory = { url, callbackURLScheme, appNameScheme, completionHandler  in
+            let mock = ASWebAuthenticationSessionMock(url: url, callbackURLScheme: appNameScheme, completionHandler: completionHandler)
             mock.code = code
 
             XCTAssertEqual(callbackURLScheme ?? "", self.stravaConfig.redirect_uri)
@@ -148,8 +148,8 @@ final class StravaOAuthTests: XCTestCase {
     func testCancelGetToken() {
         let code = "01020304050607"
         let error = ASWebAuthenticationSessionError(.canceledLogin)
-        let authenticationSessionFactory: StravaOAuth.AuthenticationFactory = { url, callbackURLScheme, completionHandler in
-            let mock = ASWebAuthenticationSessionMock(url: url, callbackURLScheme: callbackURLScheme, completionHandler: completionHandler)
+        let authenticationSessionFactory: StravaOAuth.AuthenticationFactory = { url, appSchemeName, callbackURLScheme, completionHandler  in
+            let mock = ASWebAuthenticationSessionMock(url: url, callbackURLScheme: appSchemeName, completionHandler: completionHandler)
             mock.code = code
             mock.error = error
             return mock

--- a/Tests/StravaCombineTests/StravaUploadTests.swift
+++ b/Tests/StravaCombineTests/StravaUploadTests.swift
@@ -5,7 +5,7 @@ import Combine
 
 final class StravaUploadTests: XCTestCase {
     private var cancellable: AnyCancellable?
-    let stravaConfig = StravaConfig(client_id: "client", client_secret: "secret", redirect_uri: "travaartje://www.travaartje.net")
+    let stravaConfig = StravaConfig(client_id: "client", client_secret: "secret", redirect_uri: "travaartje://www.travaartje.net", redirect_schema_name: "travaartje")
     
     /// Test the upload of a file to Strava, and check that the upload is completed
     func testUpload() {


### PR DESCRIPTION
 Config's `redirect_uri` are composed of schemeName://URL, however `ASWebAuthenticationSession` does not support `://`in the URL.
**Source:** [ASWebAuthenticationSession's callbackURLScheme crash](https://developer.apple.com/forums/thread/679251?answerId=676913022#676913022) 
**Solution:** Added a new property in the Config Model as `redirect_schema_name` that will be passed to `ASWebAuthenticationSession`"
- [x] Implementation
- [x] Unit Test